### PR TITLE
feat Script Renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A set of streamlined CLI tools for AWS management, including SSM Session Manager
 ## Features
 
 - **quickssm**: Connect to EC2 instances using short region codes 
-- **auth_aws**: Streamlined AWS SSO authentication with account and role selection
+- **authaws**: Streamlined AWS SSO authentication with account and role selection
 - Interactive listing of available instances and accounts
 - Automatic validation of AWS CLI and required plugins
 - Support for multiple AWS regions
@@ -21,21 +21,21 @@ A set of streamlined CLI tools for AWS management, including SSM Session Manager
 - AWS credentials configured (`aws configure`)
 - Bash or Zsh shell
 - Proper IAM permissions for SSM Session Manager and SSO access
-- Additional utilities: `jq` and `fzf` (required for `aws_auth`)
+- Additional utilities: `jq` and `fzf` (required for `authaws`)
 
 ## Quick Start
 
 One-liner to download, install, and start using both tools (for bash users):
 ```bash
-git clone https://github.com/ZSoftly/quickssm.git && cd quickssm && chmod +x ssm auth_aws && ./ssm check && echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.bashrc && source ~/.bashrc
+git clone https://github.com/ZSoftly/quickssm.git && cd quickssm && chmod +x ssm authaws && ./ssm check && echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.bashrc && source ~/.bashrc
 ```
 
 For zsh users:
 ```bash
-git clone https://github.com/ZSoftly/quickssm.git && cd quickssm && chmod +x ssm auth_aws && ./ssm check && echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.zshrc && source ~/.zshrc
+git clone https://github.com/ZSoftly/quickssm.git && cd quickssm && chmod +x ssm authaws && ./ssm check && echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.zshrc && source ~/.zshrc
 ```
 
-After running the appropriate command for your shell, you can use the tools by simply typing `ssm` or `auth_aws` from anywhere.
+After running the appropriate command for your shell, you can use the tools by simply typing `ssm` or `authaws` from anywhere.
 
 ## Installation Options
 
@@ -45,9 +45,9 @@ For bash users:
 ```bash
 git clone https://github.com/ZSoftly/quickssm.git
 cd quickssm
-chmod +x ssm auth_aws
+chmod +x ssm authaws
 ./ssm check
-./auth_aws check
+./authaws check
 echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.bashrc
 source ~/.bashrc
 ```
@@ -56,9 +56,9 @@ For zsh users:
 ```bash
 git clone https://github.com/ZSoftly/quickssm.git
 cd quickssm
-chmod +x ssm auth_aws
+chmod +x ssm authaws
 ./ssm check
-./auth_aws check
+./authaws check
 echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.zshrc
 source ~/.zshrc
 ```
@@ -75,12 +75,12 @@ This is the recommended approach because:
 ```bash
 git clone https://github.com/ZSoftly/quickssm.git
 cd quickssm
-chmod +x ssm auth_aws
+chmod +x ssm authaws
 ./ssm check
-./auth_aws check
+./authaws check
 INSTALL_DIR="$(pwd)"
 sudo ln -s "$INSTALL_DIR/ssm" /usr/local/bin/ssm
-sudo ln -s "$INSTALL_DIR/auth_aws" /usr/local/bin/auth_aws
+sudo ln -s "$INSTALL_DIR/authaws" /usr/local/bin/authaws
 sudo ln -s "$INSTALL_DIR/src" /usr/local/bin/src
 ```
 
@@ -90,6 +90,45 @@ Not recommended because:
 - Requires sudo privileges for updates and modifications
 - Can lead to security and audit tracking complications
 - Makes it harder to manage different AWS configurations for different users
+
+## Updating from Previous Versions
+
+If you're updating from a previous version that used `auth_aws` instead of `authaws`, follow these steps:
+
+### Option 1: Clean Update (Recommended)
+```bash
+# Navigate to your quickssm directory
+cd /path/to/quickssm
+
+# Backup your .env file if you have one
+cp .env .env.backup
+
+# Pull the latest changes
+git pull
+
+# Make the new scripts executable
+chmod +x ssm authaws
+
+# Remove the old symlink if you had one
+rm -f /usr/local/bin/auth_aws  # May require sudo
+
+# Update your path if needed or recreate symlinks
+```
+
+### Option 2: In-place Migration
+```bash
+# Navigate to your quickssm directory
+cd /path/to/quickssm
+
+# Pull the latest changes
+git pull
+
+# Make the new script executable
+chmod +x authaws
+
+# Create a symlink from the old name to the new script for compatibility
+ln -s "$(pwd)/authaws" "$(pwd)/auth_aws"
+```
 
 ## Usage
 
@@ -120,23 +159,23 @@ ssm help
 
 #### First-time Setup
 ```bash
-auth_aws check       # Check dependencies
-auth_aws help        # Show help information
+authaws check       # Check dependencies
+authaws help        # Show help information
 ```
 
-Before using `auth_aws`, set up a `.env` file in the same directory with the following content:
+Before using `authaws`, set up a `.env` file in the same directory with the following content:
 ```
 SSO_START_URL="https://your-sso-url.awsapps.com/start"
 SSO_REGION="your-region"
 DEFAULT_PROFILE="your-default-profile"
 ```
 
-You can create a template file by running `auth_aws` without a valid .env file.
+You can create a template file by running `authaws` without a valid .env file.
 
 #### Log in to AWS SSO
 ```bash
-auth_aws             # Use default profile from .env
-auth_aws myprofile   # Use a specific profile name
+authaws             # Use default profile from .env
+authaws myprofile   # Use a specific profile name
 ```
 
 The tool will:
@@ -145,6 +184,14 @@ The tool will:
 3. Show an interactive list of accounts
 4. Show an interactive list of roles for the selected account
 5. Configure your AWS profile with the selected account and role
+
+#### View AWS Credentials
+```bash
+authaws creds           # Show credentials for current profile
+authaws creds myprofile # Show credentials for a specific profile
+```
+
+This will display your AWS access key, secret key, and session token for the specified profile.
 
 ## Supported Regions (for SSM tool)
 
@@ -222,6 +269,9 @@ If the commands aren't available after installation, make sure you've added them
 
 You may need to restart your terminal or run `source ~/.bashrc` (or `source ~/.zshrc` for Zsh) for the changes to take effect.
 
+### Script Name Changed
+If you're getting "command not found" for `auth_aws`, note that the script has been renamed to `authaws` in v1.4.0+. Update your scripts and aliases accordingly.
+
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
@@ -235,6 +285,36 @@ Key areas for contribution:
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Releasing a New Version
+
+For maintainers who want to create a new release:
+
+```bash
+# Make sure you're on the main branch
+git checkout main
+
+# Pull the latest changes (including merged PRs)
+git pull origin main
+
+# Ensure all changes are committed and the working directory is clean
+git status
+
+# Create an annotated tag
+git tag -a v1.x.x -m "Version 1.x.x: Brief description of changes"
+
+# Push the tag to GitHub
+git push origin v1.x.x
+```
+
+After pushing the tag, go to the GitHub repository and:
+1. Click on "Releases"
+2. Click "Draft a new release"
+3. Select the tag you just pushed
+4. Add release notes
+5. Publish the release
+
+This process ensures that releases are always created from the stable main branch after code has been properly reviewed and merged.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ A set of streamlined CLI tools for AWS management, including SSM Session Manager
 
 One-liner to download, install, and start using both tools (for bash users):
 ```bash
-git clone https://github.com/ZSoftly/quickssm.git && cd quickssm && chmod +x ssm authaws && ./ssm check && echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.bashrc && source ~/.bashrc
+git clone https://github.com/ZSoftly/quickssm.git && cd quickssm && chmod +x ssm authaws && ./ssm check && echo -e "\n# Add quickssm to PATH\nexport PATH=\"\$PATH:$(pwd)\"" >> ~/.bashrc && source ~/.bashrc
 ```
 
 For zsh users:
 ```bash
-git clone https://github.com/ZSoftly/quickssm.git && cd quickssm && chmod +x ssm authaws && ./ssm check && echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.zshrc && source ~/.zshrc
+git clone https://github.com/ZSoftly/quickssm.git && cd quickssm && chmod +x ssm authaws && ./ssm check && echo -e "\n# Add quickssm to PATH\nexport PATH=\"\$PATH:$(pwd)\"" >> ~/.zshrc && source ~/.zshrc
 ```
 
 After running the appropriate command for your shell, you can use the tools by simply typing `ssm` or `authaws` from anywhere.
@@ -48,7 +48,7 @@ cd quickssm
 chmod +x ssm authaws
 ./ssm check
 ./authaws check
-echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.bashrc
+echo -e "\n# Add quickssm to PATH\nexport PATH=\"\$PATH:$(pwd)\"" >> ~/.bashrc
 source ~/.bashrc
 ```
 
@@ -59,7 +59,7 @@ cd quickssm
 chmod +x ssm authaws
 ./ssm check
 ./authaws check
-echo "export PATH=\"\$PATH:$(pwd)\"" >> ~/.zshrc
+echo -e "\n# Add quickssm to PATH\nexport PATH=\"\$PATH:$(pwd)\"" >> ~/.zshrc
 source ~/.zshrc
 ```
 

--- a/authaws
+++ b/authaws
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # AWS SSO Authentication Helper Script
-# Version: 1.1.0
+# Version: 1.4.0
 # Repository: https://github.com/ZSoftly/quickssm
 
 set -e  # Exit on error
@@ -11,7 +11,7 @@ set -u  # Exit on undefined variables
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
+CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Get the directory where the script is located
@@ -32,20 +32,20 @@ log() {
 }
 
 # Logging functions with colors for terminal and regular logging for file
-log_info() { 
+log_info() {
   echo -e "${GREEN}[INFO]${NC} $1"
   log "[INFO] $1"
 }
-log_warn() { 
+log_warn() {
   echo -e "${YELLOW}[WARN]${NC} $1"
   log "[WARN] $1"
 }
-log_error() { 
+log_error() {
   echo -e "${RED}[ERROR]${NC} $1"
   log "[ERROR] $1"
 }
-log_debug() { 
-  echo -e "${BLUE}[DEBUG]${NC} $1"
+log_debug() {
+  echo -e "${CYAN}[DEBUG]${NC} $1"
   log "[DEBUG] $1"
 }
 
@@ -82,13 +82,14 @@ EOL
 show_help() {
   cat << 'EOL'
 AWS SSO Authentication Helper
-Usage: auth_aws [profile-name]
-       auth_aws              # Uses default profile from .env file
+Usage: authaws [profile-name]
+       authaws              # Uses default profile from .env file
 
 Commands:
-  auth_aws help       # Show this help message
-  auth_aws version    # Show version information
-  auth_aws check      # Check system requirements
+  authaws help       # Show this help message
+  authaws version    # Show version information
+  authaws check      # Check system requirements
+  authaws creds      # Show decoded credentials for a profile
 
 Setup:
   Before first use, create a .env file in the script directory with:
@@ -97,19 +98,22 @@ Setup:
   DEFAULT_PROFILE="your-default-profile"
 
 Examples:
-  auth_aws                # Login with default profile
-  auth_aws dev-profile    # Login with specific profile
-  auth_aws check          # Verify dependencies
+  authaws                # Login with default profile
+  authaws dev-profile    # Login with specific profile
+  authaws check          # Verify dependencies
+  authaws creds [profile]  # Show credentials for a profile
 EOL
   exit 0
 }
 
 # Show version information
-VERSION="1.0.0"
+VERSION="1.4.0"
 show_version() {
   echo "AWS SSO Authentication Helper version: $VERSION"
   exit 0
 }
+
+
 
 # Check system requirements
 check_requirements() {
@@ -164,6 +168,53 @@ is_token_valid() {
   [[ "$expires_at" > "$current_time" ]]
 }
 
+# Show decoded credentials for a profile
+show_credentials() {
+  local profile_name="$1"
+  
+  log_info "🔐 Retrieving credentials for profile: $profile_name"
+  
+  # Check if the profile exists in AWS config
+  if ! aws configure list --profile "$profile_name" &>/dev/null; then
+    # If it's truly a non-existent profile, there will be no entry in ~/.aws/config
+    if ! grep -q "\[profile $profile_name\]" ~/.aws/config 2>/dev/null; then
+      log_error "❌ Profile '$profile_name' does not exist"
+      log_info "You can create this profile by running: authaws $profile_name"
+      return 1
+    fi
+  fi
+  
+  # Try to export credentials
+  local creds_output
+  if ! creds_output=$(aws configure export-credentials --profile "$profile_name" --format env 2>&1); then
+    # Check if this is a credential error or some other issue
+    if echo "$creds_output" | grep -q "The SSO session has expired or is invalid"; then
+      log_error "❌ Your SSO session for profile '$profile_name' has expired"
+      log_info "Please authenticate first by running: authaws $profile_name"
+      return 1
+    elif echo "$creds_output" | grep -q "NoCredentialProviders"; then
+      log_error "❌ No credentials found for profile '$profile_name'"
+      log_info "Please authenticate first by running: authaws $profile_name"
+      return 1
+    else
+      log_error "❌ Failed to export credentials: $creds_output"
+      log_info "Try authenticating with: authaws $profile_name"
+      return 1
+    fi
+  fi
+  
+  # Display the credentials
+  echo ""
+  log_info "🔑 AWS Credentials for profile: $profile_name"
+  log_info "----------------------------------------"
+  echo "$creds_output"
+  log_info "----------------------------------------"
+  log_info "To use these credentials in your current shell, run:"
+  log_info "eval \$(aws configure export-credentials --profile $profile_name --format env)"
+  
+  return 0
+}
+
 # Main function
 main() {
   # Handle special commands first
@@ -182,6 +233,26 @@ main() {
         exit 1
       fi
       exit 0
+      ;;
+    "creds")
+      if [[ $# -lt 2 ]]; then
+        # If no profile specified, try to use the current AWS_PROFILE or the default profile
+        local cred_profile="${AWS_PROFILE:-}"
+        if [[ -z "$cred_profile" ]]; then
+          if [[ -f "${ENV_FILE}" ]]; then
+            source "${ENV_FILE}"
+            cred_profile="$DEFAULT_PROFILE"
+          else
+            log_error "No profile specified and no default profile found"
+            log_info "Usage: $0 creds [profile-name]"
+            exit 1
+          fi
+        fi
+        show_credentials "$cred_profile"
+      else
+        show_credentials "$2"
+      fi
+      exit $?
       ;;
   esac
 
@@ -241,7 +312,8 @@ main() {
     log_info "✅ Cached credentials are valid."
   else
     log_warn "⚠️ Initiating AWS SSO login..."
-    aws sso login --profile "$PROFILE_NAME"
+    # Filter out the "tcgetpgrp failed" message while preserving other errors
+    aws sso login --profile "$PROFILE_NAME" 2> >(grep -v "tcgetpgrp failed: Not a tty" >&2)
     token_file=$(find_token_file)
 
     if [[ -z "$token_file" || ! -f "$token_file" ]]; then
@@ -314,6 +386,9 @@ main() {
   log_info ""
   log_info "To use this profile, run:"
   log_info "export AWS_PROFILE=$PROFILE_NAME AWS_DEFAULT_REGION=$SSO_REGION"
+  log_info ""
+  log_info "To view your credentials, run:"
+  log_info "authaws creds $PROFILE_NAME"
   log "========== AWS SSO SCRIPT EXECUTION COMPLETED =========="
   echo "" >> "$LOG_FILE"
 }


### PR DESCRIPTION
### Rename auth_aws to authaws and add credentials view feature

#### Changes
- Renamed script from `auth_aws` to `authaws` for improved usability
- Added new `creds` command to display AWS credentials
- Improved error handling with specific guidance for different scenarios
- Suppressed misleading "Not a tty" error message during SSO login
- Changed debug message color from blue to cyan for better visibility
- Updated documentation and help text
- Added release process to README

#### Testing
- Verified script functions correctly with renamed command
- Tested credentials retrieval and error handling for various scenarios
- Confirmed compatibility with existing configurations

This change maintains backward compatibility while adding useful new features for viewing credentials. Users can update by pulling the latest changes and updating their references to the script name.